### PR TITLE
Improve drilldown UX and fix Advaita timeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An interactive explorer to compare philosophical and religious traditions, with 
 - **Comparison View**: Click any aspect (e.g., "Nature of Reality") to compare it across all traditions
 - **Timeline Navigation**: Filter traditions by time period using the interactive timeline
 - **Detailed Exploration**: Drill down into each tradition for in-depth information
+- **Clickable Cards & Rows**: Select a tradition card or individual aspect row to open references and deeper details
 - **Responsive Design**: Works on desktop and mobile devices
 - **Type-Safe**: Built with TypeScript for better developer experience
 


### PR DESCRIPTION
## Summary
- make tradition cards clickable and allow clicking rows to open references tab
- track active tab in drilldown dialog
- correct Advaita Vedānta first introduction year
- document new interactions in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689c78dc934c83338c7a863d1189942b