### PR TITLE
Add product evaluation panel and restore build stability

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-type BadgeVariant = "default" | "outline" | "secondary";
+type BadgeVariant = "default" | "outline" | "secondary" | "destructive";
 
 interface BadgeProps extends React.HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;
@@ -15,6 +15,7 @@ export function Badge({
     default: "bg-primary text-primary-foreground hover:bg-primary/80 border-transparent",
     outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
     secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 border-transparent",
+    destructive: "bg-red-100 text-red-700 border-red-200",
   };
 
   return (

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "default" | "ghost" | "secondary";
+  variant?: "default" | "ghost" | "secondary" | "outline";
   size?: "sm" | "md" | "lg" | "icon";
 };
 
@@ -11,6 +11,7 @@ export function Button({ className = "", variant = "default", size = "md", ...pr
     default: "bg-black text-white hover:bg-black/90",
     ghost: "bg-transparent hover:bg-black/5",
     secondary: "bg-gray-100 hover:bg-gray-200",
+    outline: "border border-gray-300 bg-white text-gray-900 hover:bg-gray-50",
   };
   const sizes: Record<string, string> = {
     sm: "h-8 px-3",

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,25 +1,35 @@
 import * as React from "react";
 
-export function Card({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={`rounded-xl border bg-white/80 backdrop-blur shadow-sm ${className}`} {...props} />;
-}
+export const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className = "", ...props }, ref) => (
+    <div ref={ref} className={`rounded-xl border bg-white/80 backdrop-blur shadow-sm ${className}`} {...props} />
+  )
+);
+Card.displayName = "Card";
 
-export function CardHeader({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={`p-4 pb-0 ${className}`} {...props} />;
-}
+export const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className = "", ...props }, ref) => <div ref={ref} className={`p-4 pb-0 ${className}`} {...props} />
+);
+CardHeader.displayName = "CardHeader";
 
-export function CardTitle({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <h3 className={`text-lg font-semibold leading-none tracking-tight ${className}`} {...props} />;
-}
+export const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className = "", ...props }, ref) => (
+    <h3 ref={ref} className={`text-lg font-semibold leading-none tracking-tight ${className}`} {...props} />
+  )
+);
+CardTitle.displayName = "CardTitle";
 
-export function CardDescription({ className = "", ...props }: React.HTMLAttributes<HTMLParagraphElement>) {
-  return <p className={`text-sm text-muted-foreground ${className}`} {...props} />;
-}
+export const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className = "", ...props }, ref) => <p ref={ref} className={`text-sm text-muted-foreground ${className}`} {...props} />
+);
+CardDescription.displayName = "CardDescription";
 
-export function CardContent({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={`p-4 pt-2 ${className}`} {...props} />;
-}
+export const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className = "", ...props }, ref) => <div ref={ref} className={`p-4 pt-2 ${className}`} {...props} />
+);
+CardContent.displayName = "CardContent";
 
-export function CardFooter({ className = "", ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={`flex items-center p-4 pt-0 ${className}`} {...props} />;
-}
+export const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className = "", ...props }, ref) => <div ref={ref} className={`flex items-center p-4 pt-0 ${className}`} {...props} />
+);
+CardFooter.displayName = "CardFooter";

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -7,11 +7,31 @@ type TabsContextType = {
 
 const TabsContext = React.createContext<TabsContextType | null>(null);
 
-export function Tabs({ defaultValue, className = "", children }: { defaultValue: string; className?: string; children: React.ReactNode }) {
-  const [value, setValue] = React.useState(defaultValue);
+type TabsProps = {
+  defaultValue?: string;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  className?: string;
+  children: React.ReactNode;
+};
+
+export function Tabs({ defaultValue, value, onValueChange, className = "", children }: TabsProps) {
+  const [internalValue, setInternalValue] = React.useState(defaultValue ?? value ?? "");
+  const currentValue = value ?? internalValue;
+
+  const setValue = React.useCallback(
+    (nextValue: string) => {
+      if (value === undefined) {
+        setInternalValue(nextValue);
+      }
+      onValueChange?.(nextValue);
+    },
+    [onValueChange, value]
+  );
+
   return (
     <div className={className}>
-      <TabsContext.Provider value={{ value, setValue }}>{children}</TabsContext.Provider>
+      <TabsContext.Provider value={{ value: currentValue, setValue }}>{children}</TabsContext.Provider>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -29,3 +29,21 @@ body {
 [data-tooltip-content] {
   z-index: 9999 !important;
 }
+
+#timeline-scroll::-webkit-scrollbar {
+  height: 8px;
+}
+
+#timeline-scroll::-webkit-scrollbar-track {
+  background: #f1f5f9;
+  border-radius: 4px;
+}
+
+#timeline-scroll::-webkit-scrollbar-thumb {
+  background: #cbd5e1;
+  border-radius: 4px;
+}
+
+#timeline-scroll::-webkit-scrollbar-thumb:hover {
+  background: #94a3b8;
+}

--- a/src/pages/ExplorerWithEnhancements.tsx
+++ b/src/pages/ExplorerWithEnhancements.tsx
@@ -397,22 +397,7 @@ const ExplorerWithEnhancements: React.FC = () => {
                     );
                   })}
                 </div>
-                <style jsx>{`
-                  div::-webkit-scrollbar {
-                    height: 8px;
-                  }
-                  div::-webkit-scrollbar-track {
-                    background: #f1f5f9;
-                    border-radius: 4px;
-                  }
-                  div::-webkit-scrollbar-thumb {
-                    background: #cbd5e1;
-                    border-radius: 4px;
-                  }
-                  div::-webkit-scrollbar-thumb:hover {
-                    background: #94a3b8;
-                  }
-                `}</style>
+
               </CardContent>
             </Card>
 

--- a/src/pages/MainDashboard.tsx
+++ b/src/pages/MainDashboard.tsx
@@ -11,19 +11,13 @@ import {
   BookOpen, 
   Skull, 
   TrendingUp,
-  Users,
-  Globe,
-  Calendar,
   ArrowRight,
   ChevronLeft,
   Lightbulb,
   History,
   Library,
   Compass,
-  Timeline,
-  Scroll,
-  Mountain,
-  TreePine
+  Mountain
 } from 'lucide-react';
 
 // Import our components
@@ -45,7 +39,7 @@ const MainDashboard: React.FC = () => {
       key: 'wisdom' as ViewType,
       title: 'Wisdom Explorer',
       subtitle: 'Explore Living Traditions',
-      description: 'Discover and compare 15 major philosophical and religious traditions from around the world. From ancient Buddhism to modern Existentialism.',
+      description: 'Discover and compare major philosophical and religious traditions from around the world. From ancient Buddhism to modern Existentialism.',
       icon: Library,
       color: 'blue',
       stats: [
@@ -86,7 +80,7 @@ const MainDashboard: React.FC = () => {
       title: 'Evolution of Ideas',
       subtitle: 'Ideas Through Time',
       description: 'Track how core philosophical concepts like reality, self, and meaning have evolved across 100,000 years of human thought.',
-      icon: Timeline,
+      icon: TrendingUp,
       color: 'purple',
       stats: [
         { label: 'Years Tracked', value: '100k+' },
@@ -101,6 +95,34 @@ const MainDashboard: React.FC = () => {
       accentColor: 'text-purple-600',
       iconBg: 'bg-purple-100'
     }
+  ];
+
+
+  const productDirection = [
+    {
+      icon: Compass,
+      title: 'Concept map, not just a catalog',
+      description: 'The strongest thread is a guided map of how traditions answer recurring human questions about reality, selfhood, suffering, practice, and flourishing.'
+    },
+    {
+      icon: Skull,
+      title: 'Survivor-bias lens',
+      description: 'The lost-traditions area reframes the project from “greatest hits” history into a critical tool about power, preservation, and forgotten alternatives.'
+    },
+    {
+      icon: History,
+      title: 'Historical development engine',
+      description: 'The evolution view points toward showing influence, divergence, and recurring patterns across time instead of isolated summaries.'
+    }
+  ];
+
+  const enhancementAreas = [
+    'Add guided learning paths for students and teachers with prompts, checkpoints, and short classroom activities.',
+    'Add side-by-side compare mode where users can pin 2–4 traditions and export a comparison table.',
+    'Add source-quality metadata, citation filters, and notes on contested dates or scholarly uncertainty.',
+    'Add visual influence links between traditions, extinct movements, and modern descendants.',
+    'Add glossary and accessibility refinements for terms such as BCE, nonduality, dharma, covenant, and anatta.',
+    'Add persistence for saved traditions, recently viewed cards, and shareable deep links.'
   ];
 
   const currentTile = tiles.find(t => t.key === currentView);
@@ -202,7 +224,7 @@ const MainDashboard: React.FC = () => {
                     <CardTitle className="text-xl">{tile.title}</CardTitle>
                   </div>
                   <CardDescription className="text-sm">
-                    {tile.key === 'wisdom' ? 'Compare 15 philosophical and religious traditions' :
+                    {tile.key === 'wisdom' ? `Compare ${DATA.length} philosophical and religious traditions` :
                      tile.key === 'survivor' ? 'Explore traditions lost to history' :
                      'Track how ideas evolved over time'}
                   </CardDescription>
@@ -238,6 +260,56 @@ const MainDashboard: React.FC = () => {
               </Card>
             );
           })}
+        </div>
+
+        {/* Product Evaluation */}
+        <div className="grid lg:grid-cols-2 gap-8 mb-16">
+          <Card className="border-blue-100">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Lightbulb className="h-5 w-5 text-blue-600" />
+                Where this is going
+              </CardTitle>
+              <CardDescription>
+                The app is becoming an educational thinking tool: part explorer, part timeline, part critical-history companion.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {productDirection.map(({ icon: Icon, title, description }) => (
+                <div key={title} className="flex gap-3">
+                  <div className="mt-1 rounded-full bg-blue-50 p-2">
+                    <Icon className="h-4 w-4 text-blue-600" />
+                  </div>
+                  <div>
+                    <h3 className="text-sm font-semibold">{title}</h3>
+                    <p className="text-sm text-gray-600">{description}</p>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          <Card className="border-amber-100">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Compass className="h-5 w-5 text-amber-600" />
+                Highest-value enhancements
+              </CardTitle>
+              <CardDescription>
+                These additions would make the project more functional for learning, research, and classroom use.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-3">
+                {enhancementAreas.map((area) => (
+                  <li key={area} className="flex items-start gap-2 text-sm text-gray-700">
+                    <ArrowRight className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-600" />
+                    <span>{area}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
         </div>
 
         {/* Simple Footer */}


### PR DESCRIPTION
### Motivation
- Make the product direction explicit by adding a short dashboard evaluation that frames the app as a concept-map explorer with survivor-bias and historical-evolution lenses. 
- Surface a short list of high-value enhancements to prioritize features for learning, classroom use, and research workflows. 
- Restore type/build stability so the app compiles and can be iterated on safely.

### Description
- Added a dashboard “Product Evaluation” section with `productDirection` and `enhancementAreas` content and a small UI panel on the main dashboard (`src/pages/MainDashboard.tsx`).
- Fixed build/type issues by replacing the unavailable `Timeline` Lucide icon with `TrendingUp`, making the wisdom tile count data-driven (`DATA.length`), and moving timeline scrollbar styling out of unsupported JSX into global CSS (`src/index.css` / `#timeline-scroll`).
- Expanded UI primitives to match usage across the app by adding `outline` to `Button` variants, adding `destructive` to `Badge` variants, supporting controlled `Tabs` (`value`/`onValueChange`) and forwarding refs from `Card` components (`src/components/ui/*`).
- Cleaned `ExplorerWithEnhancements.tsx` to remove inline JSX styles for scrollbars and rely on the global CSS rule; minor copy/timing improvements to aid UX.

### Testing
- Ran `npx tsc --noEmit` and the type-check completed successfully. 
- Built a production bundle with `npm run build` and the build completed successfully. 
- Launched the dev server with `npm run dev` to confirm local app start (dev server reported ready). 
- Attempted a headless screenshot via `npx playwright screenshot`, but installation failed due to the environment npm registry policy returning `403 Forbidden` (tooling installation issue, not a code/build failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe2cc7652883338275b0bb79511cf2)